### PR TITLE
Add a guard to make sure no output is printed in "--headless" mode;

### DIFF
--- a/lua/telescope/_extensions/vim_bookmarks.lua
+++ b/lua/telescope/_extensions/vim_bookmarks.lua
@@ -98,9 +98,13 @@ local function make_bookmark_picker(filenames, opts)
     local make_finder = function()
         local bookmarks = get_bookmarks(filenames, opts)
 
-        if vim.tbl_isempty(bookmarks) then 
-            print("No bookmarks!")
-            return
+        if vim.tbl_isempty(bookmarks) then
+            if vim.tbl_isempty(vim.call("nvim_list_uis")) then
+                return
+            else
+                print("No bookmarks!")
+                return
+            end
         end
 
         return finders.new_table {
@@ -118,8 +122,8 @@ local function make_bookmark_picker(filenames, opts)
         previewer = conf.qflist_previewer(opts),
         sorter = conf.generic_sorter(opts),
 
-        attach_mappings = function(prompt_bufnr, map) 
-            local refresh_picker = function() 
+        attach_mappings = function(prompt_bufnr, map)
+            local refresh_picker = function()
                 local new_finder = make_finder()
                 if new_finder then
                     action_state.get_current_picker(prompt_bufnr):refresh(make_finder())


### PR DESCRIPTION
Hi!
First of all, thank you for the plugin, it is very very helpful.
I would greatly appreciate if you choose to accept this tiny contribution. Please consider the description below:

# Description of the problem at hand

Whenever I start neovim in headless mode (using the `--headless` flag), this plugin is loaded, and, due to the fact that not all of my repos have any bookmarks what so ever, sometimes I get the "No bookmakrs!" output from `lua/telescope/_extensions/vim_bookmarks.lua:102` in the base; This may or may not mess up my downstream scripts if those happen to make use of the output printed by neovim;

# Proposed mitigation

As suggested by lines 101-104 in `lua/telescope/_extensions/vim_bookmarks.lua` from the cl, check if neovim is being launched in headless mode, if not - allow the warning print, block if otherwise; the check is done through `nvim_list_uis`, which returns empty (`nil`-table) in case of `headless` mode;

Thank you for reviewing!
