### PR TITLE
Remove trailing space in bookmark content

### DIFF
--- a/lua/telescope/_extensions/vim_bookmarks.lua
+++ b/lua/telescope/_extensions/vim_bookmarks.lua
@@ -30,7 +30,7 @@ local function get_bookmarks(files, opts)
                     filename = file,
                     lnum = tonumber(line),
                     col=1,
-                    text = text,
+                    text = text:gsub("^%s+", ""),
                     sign_idx = bookmark.sign_idx,
                 })
             end


### PR DESCRIPTION
Hi.

First of all, thank you for the plugin, it is very very helpful to me while working with nvim.

After working with some HTML files. I saw the text in the list has a 
little bit weird with some unnecessary space

![telegram-cloud-photo-size-5-6194766408198500172-y](https://user-images.githubusercontent.com/5939997/146672990-aa976bb1-e5e0-4c0b-b774-068ea8654802.jpg)

This is my pull request to trim space and result

![image](https://user-images.githubusercontent.com/5939997/146673028-bcda2169-9829-4ab1-8d6f-4f002c3246dd.png)


Thank you for reviewing!

P/S: Sorry for my poor English.