### PR TITLE
Fix Issue #15 by replacing utils.get_defaults

### DIFF
--- a/lua/telescope/_extensions/vim_bookmarks.lua
+++ b/lua/telescope/_extensions/vim_bookmarks.lua
@@ -42,7 +42,7 @@ end
 
 local function make_entry_from_bookmarks(opts)
     opts = opts or {}
-    opts.tail_path = utils.get_default(opts.tail_path, true)
+    opts.tail_path = vim.F.if_nil(opts.tail_path, true)
 
     local displayer = entry_display.create {
         separator = "▏",


### PR DESCRIPTION
Part of the cleanup in https://github.com/nvim-telescope/telescope.nvim/pull/2063 removed utils.get_default. The deprecation notice there suggest we use the default vim.F.if_nil instead, which works the same way.